### PR TITLE
Add first attempt at generic subsampling

### DIFF
--- a/phylogenetic/Snakefile
+++ b/phylogenetic/Snakefile
@@ -38,7 +38,7 @@ rule files:
 
 files = rules.files.params
 
-
+include: "rules/subsampling_manual.smk"
 include: "rules/prepare_sequences.smk"
 include: "rules/construct_phylogeny.smk"
 include: "rules/annotate_phylogeny.smk"

--- a/phylogenetic/Snakefile
+++ b/phylogenetic/Snakefile
@@ -39,6 +39,10 @@ rule files:
 files = rules.files.params
 
 include: "rules/subsampling_manual.smk"
+
+if config.get("subsampling", False):
+    include: "rules/subsampling_configurable.smk"
+
 include: "rules/prepare_sequences.smk"
 include: "rules/construct_phylogeny.smk"
 include: "rules/annotate_phylogeny.smk"

--- a/phylogenetic/config/defaults.yaml
+++ b/phylogenetic/config/defaults.yaml
@@ -1,1 +1,11 @@
 strain_id_field: "accession"
+# root: "A/Sample/2009"
+
+subsampling:
+  all: --min-length '9800' --query "country == 'USA' & accession != 'NC_009942'"
+
+# subsampling:
+#   state: --query "division == 'WA'"
+#   neighboring_state: --query "division in ['ID', 'OR']" --group-by division year --subsample-max-sequences 200
+#   country: --query "country == 'USA' and division not in ['WA', 'ID', 'OR']" --group-by division year --subsample-max-sequences 200
+#   global: --query "country != 'USA'" --group-by country year --subsample-max-sequences 200

--- a/phylogenetic/config/defaults.yaml
+++ b/phylogenetic/config/defaults.yaml
@@ -5,8 +5,8 @@ strain_id_field: "accession"
   #all: --min-length '9800' --query "country == 'USA' & accession != 'NC_009942'"
 
 subsampling:
-   state: --query "division == 'WA'"
-   neighboring_state: --query "division in ['CA', 'ID', 'OR', 'NV']" --group-by division year
-   region: --query "division in ['AZ','NM', 'CO', 'UT', 'WY', 'MT']" --group-by division year 
-   country: --query "country == 'USA' and division not in ['WA', 'CA', 'ID', 'OR', 'NV','AZ','NM', 'CO', 'UT', 'WY', 'MT']" --group-by division year --subsample-max-sequences 300
+   state: --query "division == 'WA'" --min-length '9800' --subsample-max-sequences 5000
+   neighboring_state: --query "division in ['CA', 'ID', 'OR', 'NV']" --group-by division year --min-length '9800' --subsample-max-sequences 5000
+   region: --query "division in ['AZ','NM', 'CO', 'UT', 'WY', 'MT']" --group-by division year --min-length '9800' --subsample-max-sequences 5000
+   country: --query "country == 'USA' and division not in ['WA', 'CA', 'ID', 'OR', 'NV','AZ','NM', 'CO', 'UT', 'WY', 'MT'] and accession != 'NC_009942'" --group-by division year --subsample-max-sequences 300 --min-length '9800'
    #global: --query "country != 'USA'" --group-by country year --subsample-max-sequences 200

--- a/phylogenetic/config/defaults.yaml
+++ b/phylogenetic/config/defaults.yaml
@@ -1,11 +1,12 @@
 strain_id_field: "accession"
 # root: "A/Sample/2009"
 
-subsampling:
-  all: --min-length '9800' --query "country == 'USA' & accession != 'NC_009942'"
+#subsampling:
+  #all: --min-length '9800' --query "country == 'USA' & accession != 'NC_009942'"
 
-# subsampling:
-#   state: --query "division == 'WA'"
-#   neighboring_state: --query "division in ['ID', 'OR']" --group-by division year --subsample-max-sequences 200
-#   country: --query "country == 'USA' and division not in ['WA', 'ID', 'OR']" --group-by division year --subsample-max-sequences 200
-#   global: --query "country != 'USA'" --group-by country year --subsample-max-sequences 200
+subsampling:
+   state: --query "division == 'WA'"
+   neighboring_state: --query "division in ['CA', 'ID', 'OR', 'NV']" --group-by division year
+   region: --query "division in ['AZ','NM', 'CO', 'UT', 'WY', 'MT']" --group-by division year 
+   country: --query "country == 'USA' and division not in ['WA', 'CA', 'ID', 'OR', 'NV','AZ','NM', 'CO', 'UT', 'WY', 'MT']" --group-by division year --subsample-max-sequences 300
+   #global: --query "country != 'USA'" --group-by country year --subsample-max-sequences 200

--- a/phylogenetic/rules/prepare_sequences.smk
+++ b/phylogenetic/rules/prepare_sequences.smk
@@ -20,24 +20,6 @@ This part of the workflow usually includes the following steps:
 
 See Augur's usage docs for these commands for more details.
 """
-rule filter:
-    input:
-        metadata = "data/metadata_all.tsv",
-        sequences = "data/sequences_all.fasta"
-    output:
-        sequences = "results/sequences_filtered.fasta",
-        metadata = "results/metadata_filtered.tsv"
-    shell:
-        """
-        augur filter \
-            --sequences {input.sequences} \
-            --metadata {input.metadata} \
-            --metadata-id-columns "accession" \
-            --min-length '9800' \
-            --output {output.sequences} \
-            --query "country == 'USA' & accession != 'NC_009942'"  \
-            --output-metadata {output.metadata}
-        """
 
 rule add_authors:
     message:

--- a/phylogenetic/rules/subsampling_configurable.smk
+++ b/phylogenetic/rules/subsampling_configurable.smk
@@ -1,0 +1,66 @@
+"""
+This part of the workflow subsamples sequences for constructing the phylogenetic tree.
+
+However, this configurable subsampling allows for tierred subsampling based on values placed in the config file.
+
+REQUIRED INPUTS:
+
+    metadata    = data/metadata.tsv
+    sequences   = data/sequences.fasta
+
+OUTPUTS:
+
+    metadata_subsampled = results/metadata_filtered.tsv
+    sequences_subsampled = results/sequences_filtered.fasta
+
+This part of the workflow usually includes one or more of the following steps:
+
+    - augur filter
+
+See Augur's usage docs for these commands for more details.
+"""
+
+ruleorder: extract_subsampled_sequences_and_metadata > filter_manual
+
+rule subsample:
+    input:
+        metadata = "data/metadata_all.tsv",
+        sequences = "data/sequences_all.fasta"
+    output:
+        subsampled_strains = "results/subsampled_strains_{subsample}.txt",
+    params:
+        filters = lambda wildcards: config.get("subsampling", {}).get(wildcards.subsample, ""),
+        id_column = config["strain_id_field"],
+    shell:
+        """
+        augur filter \
+            --sequences {input.sequences} \
+            --metadata {input.metadata} \
+            --metadata-id-columns {params.id_column} \
+            {params.filters} \
+            --output-strains {output.subsampled_strains}
+        """
+
+rule extract_subsampled_sequences_and_metadata:
+    input:
+        sequences = "data/sequences_all.fasta",
+        metadata = "data/metadata_all.tsv",
+        subsampled_strains = expand("results/subsampled_strains_{subsample}.txt", subsample=list(config.get("subsampling", {}).keys()))
+    output:
+        #sequences = "results/subsampled_sequences.fasta",
+        #metadata = "results/subsampled_metadata.tsv",
+        sequences = "results/sequences_filtered.fasta",
+        metadata = "results/metadata_filtered.tsv",
+    params:
+        id_column = config["strain_id_field"],
+    shell:
+        """
+        augur filter \
+            --sequences {input.sequences} \
+            --metadata {input.metadata} \
+            --metadata-id-columns {params.id_column} \
+            --exclude-all \
+            --include {input.subsampled_strains} \
+            --output-sequences {output.sequences} \
+            --output-metadata {output.metadata}
+        """

--- a/phylogenetic/rules/subsampling_manual.smk
+++ b/phylogenetic/rules/subsampling_manual.smk
@@ -1,0 +1,38 @@
+"""
+This part of the workflow subsamples sequences for constructing the phylogenetic tree.
+
+REQUIRED INPUTS:
+
+    metadata    = data/metadata.tsv
+    sequences   = data/sequences.fasta
+
+OUTPUTS:
+
+    metadata_subsampled = results/metadata_filtered.tsv
+    sequences_subsampled = results/sequences_filtered.fasta
+
+This part of the workflow usually includes one or more of the following steps:
+
+    - augur filter
+
+See Augur's usage docs for these commands for more details.
+"""
+
+rule filter_manual:
+    input:
+        metadata = "data/metadata_all.tsv",
+        sequences = "data/sequences_all.fasta"
+    output:
+        sequences = "results/sequences_filtered.fasta",
+        metadata = "results/metadata_filtered.tsv"
+    shell:
+        """
+        augur filter \
+            --sequences {input.sequences} \
+            --metadata {input.metadata} \
+            --metadata-id-columns "accession" \
+            --min-length '9800' \
+            --output {output.sequences} \
+            --query "country == 'USA' & accession != 'NC_009942'"  \
+            --output-metadata {output.metadata}
+        """


### PR DESCRIPTION
Adds rules to extract strain names from metadata based on user-defined subsampling logic in a config file (e.g., config/builds.yaml) and then concatenate all subsampled strains into subsampled sequences and metadata files to use downstream. Adds a simple config file with two examples of subsampling logic ("all" and a geographic focused scheme).