### PR TITLE
Fix cache

### DIFF
--- a/.github/workflows/ingest-to-phylogenetic.yaml
+++ b/.github/workflows/ingest-to-phylogenetic.yaml
@@ -80,6 +80,11 @@ jobs:
             key="${s3path#*/}"
 
             s3_hash="$(aws s3api head-object --no-sign-request --bucket "$bucket" --key "$key" --query Metadata.sha256sum --output text 2>/dev/null || echo "$no_hash")"
+
+            if [[ "${s3_hash}" == "${no_hash}" ]]; then
+              echo "No Metadata.sha256sum found for ${s3_url}" >> "$GITHUB_STEP_SUMMARY"
+            fi
+
             echo "${s3_hash}" | tee -a ingest-output-sha256sum
           done
 

--- a/.github/workflows/ingest-to-phylogenetic.yaml
+++ b/.github/workflows/ingest-to-phylogenetic.yaml
@@ -65,8 +65,8 @@ jobs:
           AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}
         run: |
           s3_urls=(
-            "s3://nextstrain-data/files/workflows/WNV/all/metadata.tsv.zst"
-            "s3://nextstrain-data/files/workflows/WNV/all/sequences.fasta.zst"
+            "s3://nextstrain-data/files/workflows/WNV/metadata.tsv.zst"
+            "s3://nextstrain-data/files/workflows/WNV/sequences.fasta.zst"
           )
 
           # Code below is modified from ingest/upload-to-s3


### PR DESCRIPTION
## Description of proposed changes

Fixes the ingest-to-phylogenetic workflow cache.

1. Adds a message to the GH Action summary if the cache step did not find the `Metadata.sha256sum` for an S3 file ([example](https://github.com/nextstrain/WNV/actions/runs/11280232835/attempts/1#summary-31372835877)). 
2. Updates the S3 URLs in the cache step to match the current S3 URLs. 

## Related issue(s)

Follow up to https://github.com/nextstrain/WNV/pull/22#issuecomment-2405780818

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] [Manual run](https://github.com/nextstrain/WNV/actions/runs/11280290465) cache passes and triggers phylo workflow

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
