### PR TITLE
Add `is_lab_host` column to metadata

### DIFF
--- a/ingest/defaults/config.yaml
+++ b/ingest/defaults/config.yaml
@@ -22,6 +22,7 @@ ncbi_datasets_fields:
   - update-date
   - length
   - host-name
+  - is-lab-host
   - isolate-lineage-source
   - bioprojects
   - biosample-acc
@@ -52,6 +53,7 @@ curate:
     update-date: date_updated
     length: length
     host-name: host
+    is-lab-host: is_lab_host
     isolate-lineage-source: sample_type
     biosample-acc: biosample_accessions
     sra-accs: sra_accessions
@@ -110,6 +112,7 @@ curate:
     'location',
     'state',
     'host',
+    'is_lab_host',
     #'date_submitted',
     #'sra_accession',
     #'abbr_authors',

--- a/phylogenetic/example_data/metadata.tsv
+++ b/phylogenetic/example_data/metadata.tsv
@@ -1,70 +1,70 @@
-accession	date	region	country	division	location	state	host	authors	latitude	longitude	url	length	clade_membership
-JF957161	2006-XX-XX	North America	USA	Idaho		ID		Anez et al.			https://www.ncbi.nlm.nih.gov/nuccore/JF957161	11016	SW03
-JQ700438	2011-XX-XX	North America	USA				Homo sapiens	Anez et al.			https://www.ncbi.nlm.nih.gov/nuccore/JQ700438	11016	SW03
-JX015523	2010-08-31	North America	USA	Texas	El Paso County TX	TX	Culex tarsalis	Mann et al.			https://www.ncbi.nlm.nih.gov/nuccore/JX015523	10997	SW03
-KC333375	2012-08-04	North America	USA	Texas	Harris Co.	TX	Passer domesticus	Mann et al.			https://www.ncbi.nlm.nih.gov/nuccore/KC333375	10932	SW03
-KF704147	2010-08-01	North America	USA	Arizona	Maricopa County AZ	AZ	Culex quinquefasciatus	Plante et al.			https://www.ncbi.nlm.nih.gov/nuccore/KF704147	11008	SW03
-KF704153	2010-08-06	North America	USA	Arizona	Maricopa County AZ	AZ	Culex quinquefasciatus	Plante et al.			https://www.ncbi.nlm.nih.gov/nuccore/KF704153	11017	SW03
-KJ145829	2010-XX-XX	North America	USA				Corvus brachyrhynchos	Newman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KJ145829	10455	SW03
-KJ501117	2010-XX-XX	North America	USA				Culex tarsalis	Newman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KJ501117	10954	SW03
-KJ501118	2011-XX-XX	North America	USA				Culex tarsalis	Newman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KJ501118	11005	SW03
-KJ501120	2010-XX-XX	North America	USA				Culex tarsalis	Newman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KJ501120	10951	SW03
-KJ501121	2011-XX-XX	North America	USA				Culex tarsalis	Newman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KJ501121	11031	SW03
-KJ501122	2011-XX-XX	North America	USA				Culex tarsalis	Newman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KJ501122	11033	SW03
-KJ501124	2010-XX-XX	North America	USA				Culex tarsalis	Newman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KJ501124	11007	SW03
-KJ501170	2011-XX-XX	North America	USA				Culex tarsalis	Newman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KJ501170	10457	SW03
-KJ501222	2012-XX-XX	North America	USA				Culex	Newman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KJ501222	11029	SW03
-KJ501434	2012-XX-XX	North America	USA				Pelecanus erythrorhynchos	Newman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KJ501434	10979	WN02
-KM012172	2012-XX-XX	North America	USA	Texas		TX	Homo sapiens	Grinev et al.			https://www.ncbi.nlm.nih.gov/nuccore/KM012172	11029	SW03
-KM012177	2012-XX-XX	North America	USA	Wyoming		WY	Homo sapiens	Grinev et al.			https://www.ncbi.nlm.nih.gov/nuccore/KM012177	11029	WN02
-KR348937	2010-08-06						Culex tarsalis	Duggal et al.			https://www.ncbi.nlm.nih.gov/nuccore/KR348937	10299	SW03
-KR348938	2011-02-15						Culex tarsalis	Duggal et al.			https://www.ncbi.nlm.nih.gov/nuccore/KR348938	10263	SW03
-KR348940	2010-08-06						Culex tarsalis	Duggal et al.			https://www.ncbi.nlm.nih.gov/nuccore/KR348940	10299	SW03
-KR348941	2011-08-30						Culex tarsalis	Duggal et al.			https://www.ncbi.nlm.nih.gov/nuccore/KR348941	10299	SW03
-KR348942	2011-08-30						Culex tarsalis	Duggal et al.			https://www.ncbi.nlm.nih.gov/nuccore/KR348942	10299	SW03
-KR348944	2010-09-14						Culex tarsalis	Duggal et al.			https://www.ncbi.nlm.nih.gov/nuccore/KR348944	10299	SW03
-KR348976	2011-07-18						Culex tarsalis	Duggal et al.			https://www.ncbi.nlm.nih.gov/nuccore/KR348976	10135	SW03
-KR348977	2011-08-15						Culex tarsalis	Duggal et al.			https://www.ncbi.nlm.nih.gov/nuccore/KR348977	10216	SW03
-KR348981	2011-01-09						Culex tarsalis	Duggal et al.			https://www.ncbi.nlm.nih.gov/nuccore/KR348981	10135	SW03
-KR348993	2011-07-21						Culex tarsalis	Duggal et al.			https://www.ncbi.nlm.nih.gov/nuccore/KR348993	10260	SW03
-KT020853	2014-10-14	North America	USA				Homo sapiens	Grubaugh et al.			https://www.ncbi.nlm.nih.gov/nuccore/KT020853	10299	WN02
-KX547286	2015-09-03	North America	USA	New York	Chautauqua	NY	Culiseta	Shabman et al.	42.209869	-79.470428	https://www.ncbi.nlm.nih.gov/nuccore/KX547286	10785	WN02
-KX547353	2000-07-11	North America	USA	New York	Suffolk Co.	NY	Culex	Shabman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KX547353	10787	NY99
-KX547361	2010-08-12	North America	USA	New York	Suffolk Co.	NY	Culex	Shabman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KX547361	10787	SW03
-KX547375	2011-09-08	North America	USA	New York	Oswego Co.	NY	Culiseta	Shabman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KX547375	10787	SW03
-KX547395	2000-08-31	North America	USA	New York	Suffolk Co.	NY	Culex	Shabman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KX547395	10787	NY99
-KX547410	2012-07-30	North America	USA	New York	Oswego Co.	NY	Culiseta	Shabman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KX547410	10787	WN02
-KX547456	2012-07-31	North America	USA	New York	Chautauqua Co.	NY	Culex	Shabman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KX547456	10785	WN02
-KX547460	2013-08-06	North America	USA	New York	Madison Co.	NY	Aedes sp.	Shabman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KX547460	10787	WN02
-KX547482	2013-08-07	North America	USA	New York	Oswego Co.	NY	Culiseta	Shabman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KX547482	10787	WN02
-KX547519	2000-09-01	North America	USA	New York	Westchester Co.	NY	Culex	Shabman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KX547519	10787	NY99
-KX547548	2014-09-02	North America	USA	New York	Oswego Co.	NY	Culiseta	Shabman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KX547548	10786	WN02
-KX547552	2010-09-16	North America	USA	New York	Kings Co.	NY	Cyanocitta cristata	Shabman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KX547552	10787	SW03
-KX547602	2000-09-01	North America	USA	New York	Westchester Co.	NY	Culex	Shabman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KX547602	10787	NY99
-KY216155	2012-07-31	North America	USA				Culex pipiens	Ehrbar et al.			https://www.ncbi.nlm.nih.gov/nuccore/KY216155	11007	WN02
-MF175815	2012-10-09	North America	USA	Texas	Dallas Co. Tx	TX	Culex quinquefasciatus	Aroh et al.			https://www.ncbi.nlm.nih.gov/nuccore/MF175815	10250	SW03
-MF175827	2013-08-07	North America	USA	Texas	Dallas Co. Tx	TX	Culex quinquefasciatus	Aroh et al.			https://www.ncbi.nlm.nih.gov/nuccore/MF175827	10250	WN02
-MF175829	2013-08-06	North America	USA	Texas	Dallas Co. Tx	TX	Culex quinquefasciatus	Aroh et al.			https://www.ncbi.nlm.nih.gov/nuccore/MF175829	10250	WN02
-MF175831	2015-09-22	North America	USA	Texas	Denton Co. Tx	TX	Culex quinquefasciatus	Aroh et al.			https://www.ncbi.nlm.nih.gov/nuccore/MF175831	11032	WN02
-MF175839	2014-08-28	North America	USA	Texas	Denton Co. Tx	TX	Culex quinquefasciatus	Aroh et al.			https://www.ncbi.nlm.nih.gov/nuccore/MF175839	11031	WN02
-MF175858	2015-09-22	North America	USA	Texas	Collin Co. Tx	TX	Culex quinquefasciatus	Aroh et al.			https://www.ncbi.nlm.nih.gov/nuccore/MF175858	11032	WN02
-MF175863	2014-09-04	North America	USA	Texas	Denton Co. Tx	TX	Culex quinquefasciatus	Aroh et al.			https://www.ncbi.nlm.nih.gov/nuccore/MF175863	11032	WN02
-MF175865	2015-09-16	North America	USA	Texas	Montgomery Co. Tx	TX	Culex quinquefasciatus	Aroh et al.			https://www.ncbi.nlm.nih.gov/nuccore/MF175865	11035	WN02
-MF175866	2014-09-09	North America	USA	Texas	El Paso Co. Tx	TX	Culex tarsalis	Aroh et al.			https://www.ncbi.nlm.nih.gov/nuccore/MF175866	11032	SW03
-MF175873	2015-09-08	North America	USA	Texas	Dallas Co. Tx	TX	Culex quinquefasciatus	Aroh et al.			https://www.ncbi.nlm.nih.gov/nuccore/MF175873	11030	WN02
-MG004533	2014-06-03	North America	USA	Arizona		AZ	Culex quinquefasciatus	Hepp et al.			https://www.ncbi.nlm.nih.gov/nuccore/MG004533	10803	SW03
-MG004537	2014-08-28	North America	USA	Arizona		AZ	Culex quinquefasciatus	Hepp et al.			https://www.ncbi.nlm.nih.gov/nuccore/MG004537	10803	SW03
-MG004540	2015-05-12	North America	USA	Arizona		AZ	Culex quinquefasciatus	Hepp et al.			https://www.ncbi.nlm.nih.gov/nuccore/MG004540	10803	SW03
-MH166901	2000-XX-XX	North America	USA	Virginia	Norfolk VA	VA	Aves	Swetnam et al.			https://www.ncbi.nlm.nih.gov/nuccore/MH166901	11025	NY99
-MH166903	2000-XX-XX	North America	USA	Virginia	Norfolk VA	VA	Aves	Swetnam et al.			https://www.ncbi.nlm.nih.gov/nuccore/MH166903	11026	NY99
-MH166904	2000-XX-XX	North America	USA	Virginia	Norfolk VA	VA	Aves	Swetnam et al.			https://www.ncbi.nlm.nih.gov/nuccore/MH166904	11018	NY99
-OQ721425	2004-05-25	North America	USA	California	Los Angeles County CA	CA	Corvus brachyrhynchos	Grubaugh et al.			https://www.ncbi.nlm.nih.gov/nuccore/OQ721425	10302	WN02
-OQ721436	2015-01-01	North America	USA	Washington	Grant County WA	WA	Corvidae	Grubaugh et al.			https://www.ncbi.nlm.nih.gov/nuccore/OQ721436	10302	SW03
-HM488126	1999-XX-XX	North America	USA	Connecticut		CT	Corvus brachyrhynchos	Armstrong et al.			https://www.ncbi.nlm.nih.gov/nuccore/HM488126	10598	NY99
-HM488127	1999-XX-XX	North America	USA	Connecticut		CT	Corvus brachyrhynchos	Armstrong et al.			https://www.ncbi.nlm.nih.gov/nuccore/HM488127	10625	NY99
-HM488130	2000-XX-XX	North America	USA	Connecticut		CT	Culex salinarius	Armstrong et al.			https://www.ncbi.nlm.nih.gov/nuccore/HM488130	10621	NY99
-HM488132	2000-XX-XX	North America	USA	Connecticut		CT	Culiseta melanura	Armstrong et al.			https://www.ncbi.nlm.nih.gov/nuccore/HM488132	10621	NY99
-HQ671707	1999-XX-XX	North America	USA	Connecticut		CT	Culex pipiens	Henn et al.			https://www.ncbi.nlm.nih.gov/nuccore/HQ671707	10607	NY99
-AF202541	XXXX-XX-XX	North America	USA	New York		NY		Jia et al.			https://www.ncbi.nlm.nih.gov/nuccore/AF202541	10945	NY99
-AF206518	XXXX-XX-XX	North America	USA	Connecticut	Greenwich-Stanford Town Line	CT	Culex pipiens	Anderson et al.			https://www.ncbi.nlm.nih.gov/nuccore/AF206518	10975	NY99
-AF481864	XXXX-XX-XX						Ciconiidae	Malkinson et al.			https://www.ncbi.nlm.nih.gov/nuccore/AF481864	11029	pre-NY
+accession	date	region	country	division	location	state	host	is_lab_host	authors	latitude	longitude	url	length	clade_membership
+JF957161	2006-XX-XX	North America	USA	Idaho		ID			Anez et al.			https://www.ncbi.nlm.nih.gov/nuccore/JF957161	11016	SW03
+JQ700438	2011-XX-XX	North America	USA				Homo sapiens		Anez et al.			https://www.ncbi.nlm.nih.gov/nuccore/JQ700438	11016	SW03
+JX015523	2010-08-31	North America	USA	Texas	El Paso County TX	TX	Culex tarsalis		Mann et al.			https://www.ncbi.nlm.nih.gov/nuccore/JX015523	10997	SW03
+KC333375	2012-08-04	North America	USA	Texas	Harris Co.	TX	Passer domesticus		Mann et al.			https://www.ncbi.nlm.nih.gov/nuccore/KC333375	10932	SW03
+KF704147	2010-08-01	North America	USA	Arizona	Maricopa County AZ	AZ	Culex quinquefasciatus		Plante et al.			https://www.ncbi.nlm.nih.gov/nuccore/KF704147	11008	SW03
+KF704153	2010-08-06	North America	USA	Arizona	Maricopa County AZ	AZ	Culex quinquefasciatus		Plante et al.			https://www.ncbi.nlm.nih.gov/nuccore/KF704153	11017	SW03
+KJ145829	2010-XX-XX	North America	USA				Corvus brachyrhynchos		Newman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KJ145829	10455	SW03
+KJ501117	2010-XX-XX	North America	USA				Culex tarsalis		Newman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KJ501117	10954	SW03
+KJ501118	2011-XX-XX	North America	USA				Culex tarsalis		Newman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KJ501118	11005	SW03
+KJ501120	2010-XX-XX	North America	USA				Culex tarsalis		Newman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KJ501120	10951	SW03
+KJ501121	2011-XX-XX	North America	USA				Culex tarsalis		Newman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KJ501121	11031	SW03
+KJ501122	2011-XX-XX	North America	USA				Culex tarsalis		Newman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KJ501122	11033	SW03
+KJ501124	2010-XX-XX	North America	USA				Culex tarsalis		Newman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KJ501124	11007	SW03
+KJ501170	2011-XX-XX	North America	USA				Culex tarsalis		Newman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KJ501170	10457	SW03
+KJ501222	2012-XX-XX	North America	USA				Culex		Newman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KJ501222	11029	SW03
+KJ501434	2012-XX-XX	North America	USA				Pelecanus erythrorhynchos		Newman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KJ501434	10979	WN02
+KM012172	2012-XX-XX	North America	USA	Texas		TX	Homo sapiens		Grinev et al.			https://www.ncbi.nlm.nih.gov/nuccore/KM012172	11029	SW03
+KM012177	2012-XX-XX	North America	USA	Wyoming		WY	Homo sapiens		Grinev et al.			https://www.ncbi.nlm.nih.gov/nuccore/KM012177	11029	WN02
+KR348937	2010-08-06						Culex tarsalis		Duggal et al.			https://www.ncbi.nlm.nih.gov/nuccore/KR348937	10299	SW03
+KR348938	2011-02-15						Culex tarsalis		Duggal et al.			https://www.ncbi.nlm.nih.gov/nuccore/KR348938	10263	SW03
+KR348940	2010-08-06						Culex tarsalis		Duggal et al.			https://www.ncbi.nlm.nih.gov/nuccore/KR348940	10299	SW03
+KR348941	2011-08-30						Culex tarsalis		Duggal et al.			https://www.ncbi.nlm.nih.gov/nuccore/KR348941	10299	SW03
+KR348942	2011-08-30						Culex tarsalis		Duggal et al.			https://www.ncbi.nlm.nih.gov/nuccore/KR348942	10299	SW03
+KR348944	2010-09-14						Culex tarsalis		Duggal et al.			https://www.ncbi.nlm.nih.gov/nuccore/KR348944	10299	SW03
+KR348976	2011-07-18						Culex tarsalis		Duggal et al.			https://www.ncbi.nlm.nih.gov/nuccore/KR348976	10135	SW03
+KR348977	2011-08-15						Culex tarsalis		Duggal et al.			https://www.ncbi.nlm.nih.gov/nuccore/KR348977	10216	SW03
+KR348981	2011-01-09						Culex tarsalis		Duggal et al.			https://www.ncbi.nlm.nih.gov/nuccore/KR348981	10135	SW03
+KR348993	2011-07-21						Culex tarsalis		Duggal et al.			https://www.ncbi.nlm.nih.gov/nuccore/KR348993	10260	SW03
+KT020853	2014-10-14	North America	USA				Homo sapiens		Grubaugh et al.			https://www.ncbi.nlm.nih.gov/nuccore/KT020853	10299	WN02
+KX547286	2015-09-03	North America	USA	New York	Chautauqua	NY	Culiseta		Shabman et al.	42.209869	-79.470428	https://www.ncbi.nlm.nih.gov/nuccore/KX547286	10785	WN02
+KX547353	2000-07-11	North America	USA	New York	Suffolk Co.	NY	Culex		Shabman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KX547353	10787	NY99
+KX547361	2010-08-12	North America	USA	New York	Suffolk Co.	NY	Culex		Shabman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KX547361	10787	SW03
+KX547375	2011-09-08	North America	USA	New York	Oswego Co.	NY	Culiseta		Shabman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KX547375	10787	SW03
+KX547395	2000-08-31	North America	USA	New York	Suffolk Co.	NY	Culex		Shabman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KX547395	10787	NY99
+KX547410	2012-07-30	North America	USA	New York	Oswego Co.	NY	Culiseta		Shabman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KX547410	10787	WN02
+KX547456	2012-07-31	North America	USA	New York	Chautauqua Co.	NY	Culex		Shabman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KX547456	10785	WN02
+KX547460	2013-08-06	North America	USA	New York	Madison Co.	NY	Aedes sp.		Shabman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KX547460	10787	WN02
+KX547482	2013-08-07	North America	USA	New York	Oswego Co.	NY	Culiseta		Shabman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KX547482	10787	WN02
+KX547519	2000-09-01	North America	USA	New York	Westchester Co.	NY	Culex		Shabman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KX547519	10787	NY99
+KX547548	2014-09-02	North America	USA	New York	Oswego Co.	NY	Culiseta		Shabman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KX547548	10786	WN02
+KX547552	2010-09-16	North America	USA	New York	Kings Co.	NY	Cyanocitta cristata		Shabman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KX547552	10787	SW03
+KX547602	2000-09-01	North America	USA	New York	Westchester Co.	NY	Culex		Shabman et al.			https://www.ncbi.nlm.nih.gov/nuccore/KX547602	10787	NY99
+KY216155	2012-07-31	North America	USA				Culex pipiens		Ehrbar et al.			https://www.ncbi.nlm.nih.gov/nuccore/KY216155	11007	WN02
+MF175815	2012-10-09	North America	USA	Texas	Dallas Co. Tx	TX	Culex quinquefasciatus		Aroh et al.			https://www.ncbi.nlm.nih.gov/nuccore/MF175815	10250	SW03
+MF175827	2013-08-07	North America	USA	Texas	Dallas Co. Tx	TX	Culex quinquefasciatus		Aroh et al.			https://www.ncbi.nlm.nih.gov/nuccore/MF175827	10250	WN02
+MF175829	2013-08-06	North America	USA	Texas	Dallas Co. Tx	TX	Culex quinquefasciatus		Aroh et al.			https://www.ncbi.nlm.nih.gov/nuccore/MF175829	10250	WN02
+MF175831	2015-09-22	North America	USA	Texas	Denton Co. Tx	TX	Culex quinquefasciatus		Aroh et al.			https://www.ncbi.nlm.nih.gov/nuccore/MF175831	11032	WN02
+MF175839	2014-08-28	North America	USA	Texas	Denton Co. Tx	TX	Culex quinquefasciatus		Aroh et al.			https://www.ncbi.nlm.nih.gov/nuccore/MF175839	11031	WN02
+MF175858	2015-09-22	North America	USA	Texas	Collin Co. Tx	TX	Culex quinquefasciatus		Aroh et al.			https://www.ncbi.nlm.nih.gov/nuccore/MF175858	11032	WN02
+MF175863	2014-09-04	North America	USA	Texas	Denton Co. Tx	TX	Culex quinquefasciatus		Aroh et al.			https://www.ncbi.nlm.nih.gov/nuccore/MF175863	11032	WN02
+MF175865	2015-09-16	North America	USA	Texas	Montgomery Co. Tx	TX	Culex quinquefasciatus		Aroh et al.			https://www.ncbi.nlm.nih.gov/nuccore/MF175865	11035	WN02
+MF175866	2014-09-09	North America	USA	Texas	El Paso Co. Tx	TX	Culex tarsalis		Aroh et al.			https://www.ncbi.nlm.nih.gov/nuccore/MF175866	11032	SW03
+MF175873	2015-09-08	North America	USA	Texas	Dallas Co. Tx	TX	Culex quinquefasciatus		Aroh et al.			https://www.ncbi.nlm.nih.gov/nuccore/MF175873	11030	WN02
+MG004533	2014-06-03	North America	USA	Arizona		AZ	Culex quinquefasciatus		Hepp et al.			https://www.ncbi.nlm.nih.gov/nuccore/MG004533	10803	SW03
+MG004537	2014-08-28	North America	USA	Arizona		AZ	Culex quinquefasciatus		Hepp et al.			https://www.ncbi.nlm.nih.gov/nuccore/MG004537	10803	SW03
+MG004540	2015-05-12	North America	USA	Arizona		AZ	Culex quinquefasciatus		Hepp et al.			https://www.ncbi.nlm.nih.gov/nuccore/MG004540	10803	SW03
+MH166901	2000-XX-XX	North America	USA	Virginia	Norfolk VA	VA	Aves		Swetnam et al.			https://www.ncbi.nlm.nih.gov/nuccore/MH166901	11025	NY99
+MH166903	2000-XX-XX	North America	USA	Virginia	Norfolk VA	VA	Aves		Swetnam et al.			https://www.ncbi.nlm.nih.gov/nuccore/MH166903	11026	NY99
+MH166904	2000-XX-XX	North America	USA	Virginia	Norfolk VA	VA	Aves		Swetnam et al.			https://www.ncbi.nlm.nih.gov/nuccore/MH166904	11018	NY99
+OQ721425	2004-05-25	North America	USA	California	Los Angeles County CA	CA	Corvus brachyrhynchos		Grubaugh et al.			https://www.ncbi.nlm.nih.gov/nuccore/OQ721425	10302	WN02
+OQ721436	2015-01-01	North America	USA	Washington	Grant County WA	WA	Corvidae		Grubaugh et al.			https://www.ncbi.nlm.nih.gov/nuccore/OQ721436	10302	SW03
+HM488126	1999-XX-XX	North America	USA	Connecticut		CT	Corvus brachyrhynchos		Armstrong et al.			https://www.ncbi.nlm.nih.gov/nuccore/HM488126	10598	NY99
+HM488127	1999-XX-XX	North America	USA	Connecticut		CT	Corvus brachyrhynchos		Armstrong et al.			https://www.ncbi.nlm.nih.gov/nuccore/HM488127	10625	NY99
+HM488130	2000-XX-XX	North America	USA	Connecticut		CT	Culex salinarius		Armstrong et al.			https://www.ncbi.nlm.nih.gov/nuccore/HM488130	10621	NY99
+HM488132	2000-XX-XX	North America	USA	Connecticut		CT	Culiseta melanura		Armstrong et al.			https://www.ncbi.nlm.nih.gov/nuccore/HM488132	10621	NY99
+HQ671707	1999-XX-XX	North America	USA	Connecticut		CT	Culex pipiens		Henn et al.			https://www.ncbi.nlm.nih.gov/nuccore/HQ671707	10607	NY99
+AF202541	XXXX-XX-XX	North America	USA	New York		NY			Jia et al.			https://www.ncbi.nlm.nih.gov/nuccore/AF202541	10945	NY99
+AF206518	XXXX-XX-XX	North America	USA	Connecticut	Greenwich-Stanford Town Line	CT	Culex pipiens		Anderson et al.			https://www.ncbi.nlm.nih.gov/nuccore/AF206518	10975	NY99
+AF481864	XXXX-XX-XX						Ciconiidae		Malkinson et al.			https://www.ncbi.nlm.nih.gov/nuccore/AF481864	11029	pre-NY


### PR DESCRIPTION
## Description of proposed changes

While working on https://github.com/nextstrain/WNV/issues/20 , I realized that we needed to filter out the lab host strains in the global phylogenetic tree. This PR adds the `is_lab_host` column to the metadata and update the s3 datasets accordingly.

This will simply the subsequent phylogenetic changes (separate PR) for the global tree.

## Related issue(s)

* https://github.com/nextstrain/WNV/issues/20 

## Checklist

- [x] Checks pass

