### PR TITLE
Fix molecular clock based on literature search

### DIFF
--- a/ingest/defaults/annotations.tsv
+++ b/ingest/defaults/annotations.tsv
@@ -294,5 +294,6 @@ KT163243	date	1968-XX-XX
 AF260968	date	1951-XX-XX
 AF260968	region	Africa
 AF260968	country	Egypt
+AF260968	host	Homo sapians
 AF196835	host	Phoenicopterus chilensis
 AF196835	date	1999-XX-XX

--- a/ingest/defaults/annotations.tsv
+++ b/ingest/defaults/annotations.tsv
@@ -300,3 +300,5 @@ AF196835	date	1999-XX-XX
 AY765264	date	1997-XX-XX
 AY765264	country	Czech Republic
 AY765264	region	Europe
+DQ318020	date	1972-XX-XX
+DQ318020	host	Culex tigripes

--- a/ingest/defaults/annotations.tsv
+++ b/ingest/defaults/annotations.tsv
@@ -294,3 +294,5 @@ KT163243	date	1968-XX-XX
 AF260968	date	1951-XX-XX
 AF260968	region	Africa
 AF260968	country	Egypt
+AF196835	host	Phoenicopterus chilensis
+AF196835	date	1999-XX-XX

--- a/ingest/defaults/annotations.tsv
+++ b/ingest/defaults/annotations.tsv
@@ -297,3 +297,6 @@ AF260968	country	Egypt
 AF260968	host	Homo sapians
 AF196835	host	Phoenicopterus chilensis
 AF196835	date	1999-XX-XX
+AY765264	date	1997-XX-XX
+AY765264	country	Czech Republic
+AY765264	region	Europe

--- a/ingest/defaults/annotations.tsv
+++ b/ingest/defaults/annotations.tsv
@@ -302,3 +302,5 @@ AY765264	country	Czech Republic
 AY765264	region	Europe
 DQ318020	date	1972-XX-XX
 DQ318020	host	Culex tigripes
+D00246	country	Australia
+D00246	date	1960-XX-XX

--- a/phylogenetic/build-configs/washington-state/config.yaml
+++ b/phylogenetic/build-configs/washington-state/config.yaml
@@ -20,7 +20,7 @@ subsampling:
   force_include: --exclude-all --include ../nextclade/defaults/include.txt
 
 refine:
-  treetime_params: --coalescent opt --clock-filter-iqd 4 --date-inference marginal --date-confidence
+  treetime_params: --coalescent opt --clock-filter-iqd 4 --date-inference marginal --date-confidence --clock-rate 0.000653
 
 traits:
   metadata_columns: [

--- a/phylogenetic/defaults/config.yaml
+++ b/phylogenetic/defaults/config.yaml
@@ -69,7 +69,7 @@ subsampling:
   force_include: --exclude-all --include defaults/include.txt
 
 refine:
-  treetime_params: --coalescent opt --date-inference marginal --date-confidence
+  treetime_params: --coalescent opt --date-inference marginal --date-confidence --keep-polytomies --clock-rate 0.000755
 
 traits:
   metadata_columns: [

--- a/phylogenetic/defaults/config.yaml
+++ b/phylogenetic/defaults/config.yaml
@@ -2,7 +2,7 @@ strain_id_field: "accession"
 # Use 'Egypt 1951' as the reference and root, following Mencattelli et al, 2023
 # https://www.nature.com/articles/s41467-023-42185-7
 reference: "defaults/reference_global.gb"
-root: "AF260968"
+root: "mid_point"
 
 # Sequences must be FASTA and metadata must be TSV
 # Both files must be zstd compressed

--- a/phylogenetic/defaults/exclude.txt
+++ b/phylogenetic/defaults/exclude.txt
@@ -53,3 +53,4 @@ OM202905 # Clusters below PAT FV537222
 OM202932 # Clusters below PAT FV537222
 FV537223 # Clusters below PAT FV537222
 FV537222 # Clusters below PAT FV537222
+AY688948 # Laboratory strain Sarafend based on https://pmc.ncbi.nlm.nih.gov/articles/PMC3320449/

--- a/phylogenetic/defaults/exclude.txt
+++ b/phylogenetic/defaults/exclude.txt
@@ -1,3 +1,4 @@
+AF260968 # Egypt 1951 will added back in during augur align reference
 HW816192 # 11029 bp PAT 27-MAY-2015
 CS543188 # 11029 bp PAT 20-APR-2007
 CS568914 # 11029 bp PAT 18-MAY-2007

--- a/phylogenetic/defaults/include.txt
+++ b/phylogenetic/defaults/include.txt
@@ -1,4 +1,4 @@
-AF260968 # Egypt 1951
+# AF260968 # Egypt 1951 will be used as augur align reference
 NC_001563 # Lineage 2 reference
 NC_009942 # Lineage 1 reference
 HM051416 # Isreal 1953

--- a/phylogenetic/defaults/include.txt
+++ b/phylogenetic/defaults/include.txt
@@ -68,3 +68,24 @@ KJ501222 # SW03
 MG004537 # SW03
 MF175866 # SW03
 MG004540 # SW03
+MW383507 # Lineage 2
+HM147822 # Lineage 2
+GQ903680 # Lineage 2
+DQ176636 # Lineage 2
+KU978767 # Lineage 2
+HM147823 # Lineage 2
+PP445212 # Lineage 3
+AY765264 # Lineage 3
+AY277251 # Lineage 4
+FJ159131 # Lineage 4
+FJ159129 # Lineage 4
+FJ159130 # Lineage 4
+KJ831223 # Lineage 4
+KU978770 # Lineage 5
+DQ256376 # Lineage 5
+JX041632 # Lineage 5
+GQ851604 # Lineage 5
+GQ851605 # Lineage 5
+KY703855 # Lineage 7
+OP846972 # Lineage 7
+KY703856 # Lineage 8

--- a/phylogenetic/defaults/reference_global.gb
+++ b/phylogenetic/defaults/reference_global.gb
@@ -1,6 +1,6 @@
-LOCUS       AF260968_REF               11029 bp    RNA     linear   VRL 27-AUG-2000
+LOCUS       AF260968               11029 bp    RNA     linear   VRL 27-AUG-2000
 DEFINITION  West Nile virus strain Eg101, complete genome.
-ACCESSION   AF260968_REF
+ACCESSION   AF260968
 VERSION     AF260968.1
 KEYWORDS    .
 SOURCE      West Nile virus (WNV)


### PR DESCRIPTION
## Description of proposed changes

For the West Nile Virus (WNV) global tree, the molecular clock estimates were too low. I searched the literature to find BEAST runs of the global WNV tree estimating average and lineage-based substitution rates per position per year to set the molecular clock in our global and Washington (WA) tree refinement steps. Literature sources are listed in the commit messages.

**Before**
<img width="1204" alt="Screenshot 2024-11-01 at 10 40 43 AM" src="https://github.com/user-attachments/assets/ca0a22b3-fb56-45d2-b955-39dc4b90bf16">

View current WNV global tree: https://next.nextstrain.org/staging/WNV/genome

**After**
<img width="1212" alt="Screenshot 2024-11-01 at 10 41 35 AM" src="https://github.com/user-attachments/assets/2ed6d8fe-e5de-4a69-b05f-b4681123fc63">

View fixed WNV global tree: https://next.nextstrain.org/staging/WNV/global
From this key commit: f34b75572c1de782eec3aeb0f36cc990f54ce990

I also used a literature search to set the clock rate on the Washington-focused build

View fixed Washington state tree:  https://next.nextstrain.org/staging/WNV/WA?m=num_date
From this key commit: bf0ed7c7435c6ae3c82cebfade123f4a4b1ddf22

## Related issue(s)

* https://github.com/nextstrain/WNV/issues/36

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
