### PR TITLE
Ingest: fetch and append pathoplexus global lineage calls

### DIFF
--- a/ingest/defaults/config.yaml
+++ b/ingest/defaults/config.yaml
@@ -132,3 +132,8 @@ curate:
 nextclade:
   nextclade_dataset_path: '../nextclade/dataset'
   nextclade_field: 'clade_membership'
+
+pathoplexus:
+  URL: 'https://lapis.pathoplexus.org/west-nile/sample/details'
+  fields: 'insdcAccessionBase,lineage'
+  accession_field: 'insdcAccessionBase'

--- a/phylogenetic/defaults/auspice_config.json
+++ b/phylogenetic/defaults/auspice_config.json
@@ -7,7 +7,7 @@
     {"key": "state", "title": "State", "type": "categorical"},
     {"key": "division", "title": "Division", "type": "categorical"},
     {"key": "location", "title": "Location", "type": "categorical"},
-    {"key": "lineage", "title": "Strain", "type": "categorical"},
+    {"key": "lineage", "title": "Pathoplexus lineage", "type": "categorical"},
     {"key": "clade_membership", "title": "Clade", "type": "categorical"},
     {"key": "author", "title": "Authors", "type": "categorical"},
     {"key": "host", "title": "Host Species", "type": "categorical"}

--- a/phylogenetic/defaults/auspice_config_global.json
+++ b/phylogenetic/defaults/auspice_config_global.json
@@ -5,6 +5,8 @@
     {"key": "num_date", "title": "Sampling Date", "type": "continuous"},
     {"key": "region", "title": "Region", "type": "categorical"},
     {"key": "country", "title": "Country", "type": "categorical"},
+    {"key": "lineage", "title": "Pathoplexus lineage", "type": "categorical"},
+    {"key": "clade_membership", "title": "Clade", "type": "categorical"},
     {"key": "author", "title": "Authors", "type": "categorical"},
     {"key": "host", "title": "Host Species", "type": "categorical"}
   ],


### PR DESCRIPTION
## Description of proposed changes

This pull request adds rules to retrieve global lineage (1A, 1B, 2, 3, 4, 5, 7, 8) calls from the Pathoplexus website. After appending the Pathoplexus lineages, we can color the tree as shown at https://next.nextstrain.org/staging/WNV/pathoplexus?c=lineage

<img width="1091" alt="Screenshot 2024-11-02 at 6 00 45 PM" src="https://github.com/user-attachments/assets/1d1aae7d-71c7-4fb0-994e-a72d2148b389">

This change has the added benefit of restricting the USA-based clade calls to the 1A strains (which include most North American WNV strains) since they are based on an initial WNV case isolated in New York from 1999.

Left (original global tree); Right (fixed global tree, where USA-based clade calls restricted to 1A strains)

<img width="1086" alt="Screenshot 2024-11-02 at 6 01 14 PM" src="https://github.com/user-attachments/assets/3f378dbc-87e2-44b5-a778-612cfe176e71">

The updated tree can be viewed at https://next.nextstrain.org/staging/WNV/pathoplexus?c=clade_membership

## Related issue(s)

* Related to https://github.com/nextstrain/WNV/issues/35
* Prerequisite for https://github.com/nextstrain/WNV/issues/34
* And solves https://github.com/nextstrain/WNV/issues/25

## Checklist

- [x] Checks pass
