### PR TITLE
Ingest: annotate EF631122 and EF631123 as unknown collection date

### DIFF
--- a/ingest/defaults/annotations.tsv
+++ b/ingest/defaults/annotations.tsv
@@ -304,3 +304,5 @@ DQ318020	date	1972-XX-XX
 DQ318020	host	Culex tigripes
 D00246	country	Australia
 D00246	date	1960-XX-XX
+EF631122	date	XXXX-XX-XX
+EF631123	date	XXXX-XX-XX


### PR DESCRIPTION
## Description of proposed changes

NCBI GenBank records [EF631122](https://www.ncbi.nlm.nih.gov/nuccore/EF631122) and [EF631123](https://www.ncbi.nlm.nih.gov/nuccore/EF631123) have collection date annotations of "05-Aug-1931" in location "USA: Illinois, Cook County". This is inconsistent with known history of West Nile Virus (WNV) in the USA, as the first sequenced case should be around or after 1999.

Searching the literature of the submitters:

`EF631123` shows up in a phylogenetic tree in Figure 1 within the WN02 clade which would be consistent with a post-2002 collection date, and as far as I can tell, the paper doesn't mention a pre-1999 sample in the USA:

* Amore, G., Bertolotti, L., Hamer, G.L., Kitron, U.D., Walker, E.D., Ruiz, M.O., Brawn, J.D. and Goldberg, T.L., 2010. [Multi-year evolutionary dynamics of West Nile virus in suburban Chicago, USA, 2005–2007](https://www.researchgate.net/publication/44607902_Multi-year_evolutionary_dynamics_of_West_Nile_virus_in_suburban_Chicago_USA_2005-2007). Philosophical Transactions of the Royal Society B: Biological Sciences, 365(1548), pp.1871-1878.

I also tried searching earlier publications:

* Bertolotti, L., Kitron, U.D., Walker, E.D., Ruiz, M.O., Brawn, J.D., Loss, S.R., Hamer, G.L. and Goldberg, T.L., 2008. [Fine-scale genetic variation and evolution of West Nile Virus in a transmission “hot spot” in suburban Chicago, USA.](https://www.sciencedirect.com/science/article/pii/S0042682208000068) Virology, 374(2), pp.381-389.
* Bertolotti, L., Kitron, U. and Goldberg, T.L., 2007. [Diversity and evolution of West Nile virus in Illinois and the United States, 2002–2005.](https://www.sciencedirect.com/science/article/pii/S0042682206007847) Virology, 360(1), pp.143-149.

And concluded to set their collection dates as unknown or "XXXX-XX-XX" rather than potentially skewing downstream analysis with a set 1931 date.

## Related issue(s)

## Checklist

- [x] Checks pass

