### PR TITLE
Use IQ-Tree as the faster builder

### DIFF
--- a/phylogenetic/rules/construct_phylogeny.smk
+++ b/phylogenetic/rules/construct_phylogeny.smk
@@ -35,7 +35,6 @@ rule tree:
         augur tree \
             --alignment {input.alignment} \
             --output {output.tree} \
-            --method raxml \
             --nthreads {threads:q} 2>&1 | tee {log}
         """
 


### PR DESCRIPTION
## Description of proposed changes

Switching to IQ-Tree ([view tree here](https://next.nextstrain.org/staging/WNV/trials/iqtreeTiming/WNV/genome)) reduced runtime drastically during testing:

Before: https://github.com/nextstrain/WNV/actions/runs/11920429171 (4:57:42 ~ nearly 5 hours for the tree building benchmark)
After: https://github.com/nextstrain/WNV/actions/runs/11938827520 (0:04:13 ~ 4 minutes for the tree building benchmark)

## Related issue(s)

* https://github.com/nextstrain/WNV/issues/46

## Checklist

- [x] Checks pass
