### PR TITLE
Link out to Nextclade

### DIFF
--- a/phylogenetic/build-configs/washington-state/washington-state-rules.smk
+++ b/phylogenetic/build-configs/washington-state/washington-state-rules.smk
@@ -69,6 +69,7 @@ rule export_washington_build:
             --lat-longs {input.lat_longs} \
             --description {input.description} \
             --auspice-config {input.auspice_config} \
+            --include-root-sequence-inline \
             --output {output.auspice} 2>&1 | tee {log}
         """
 

--- a/phylogenetic/defaults/auspice_config.json
+++ b/phylogenetic/defaults/auspice_config.json
@@ -46,5 +46,18 @@
     "map_triplicate": true,
     "geo_resolution": "state",
     "distance_measure": "div"
- }
+  },
+  "extensions": {
+    "nextclade": {
+      "pathogen": {
+        "schemaVersion":"3.0.0",
+        "defaultCds": "env",
+        "attributes": {
+          "name": "West Nile Virus Washington-State-Focused Tree",
+          "reference name": "IS88",
+          "reference accession": "AF481864"
+        }
+      }
+    }
+  }
 }

--- a/phylogenetic/defaults/auspice_config_global.json
+++ b/phylogenetic/defaults/auspice_config_global.json
@@ -39,5 +39,25 @@
     "color_by": "region",
     "map_triplicate": true,
     "geo_resolution": "country"
- }
+ },
+  "extensions": {
+    "nextclade": {
+      "clade_node_attrs": [
+        {
+          "name": "lineage",
+          "displayName": "Pathoplexus lineage",
+          "description": "Global WNV lineages based on pathoplexus results."
+        }
+      ],
+      "pathogen": {
+        "schemaVersion":"3.0.0",
+        "defaultCds": "env",
+        "attributes": {
+          "name": "West Nile Virus Global Tree",
+          "reference name": "Reconstructed ancestor from global tree",
+          "reference accession": "none"
+        }
+      }
+    }
+  }
 }

--- a/phylogenetic/defaults/config.yaml
+++ b/phylogenetic/defaults/config.yaml
@@ -74,7 +74,8 @@ refine:
 traits:
   metadata_columns: [
     'region',
-    'country'
+    'country',
+    'lineage',
   ]
 
 export:

--- a/phylogenetic/rules/export.smk
+++ b/phylogenetic/rules/export.smk
@@ -51,5 +51,6 @@ rule export:
             --node-data {input.branch_lengths} {input.traits} {input.nt_muts} {input.aa_muts} \
             --description {input.description} \
             --auspice-config {input.auspice_config} \
+            --include-root-sequence-inline \
             --output {output.auspice} 2>&1 | tee {log}
         """


### PR DESCRIPTION
## Description of proposed changes

Enable linking out to Nextclade

* Add root sequence to the exported auspice json files
* Add 'lineage' to traits inference
* Add 'lineage' to global auspice config
* Add descriptive names for each of the Nextclade datasets

Working tests:

* Global dataset: https://next.nextstrain.org/staging/WNV/nextclade3
<img width="500" alt="global_linkout" src="https://github.com/user-attachments/assets/0dd9aa26-8026-4750-a88a-6d2864673ed8">
<img width="1324" alt="global_results" src="https://github.com/user-attachments/assets/b33ae2a4-c5e9-47b0-8cb9-42737eeacf3e">

* Washington focused dataset: https://next.nextstrain.org/staging/WNV/WA3

<img width="500" alt="wa_linkout" src="https://github.com/user-attachments/assets/a3252c6d-06ef-4de3-8167-8a551c0bae44">

<img width="1323" alt="wa_results" src="https://github.com/user-attachments/assets/210829f0-3270-4a59-a045-09005c40d125">

## Related issue(s)

* https://github.com/nextstrain/WNV/issues/43

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
