### PR TITLE
Switch to full_authors and authors fields

### DIFF
--- a/ingest/defaults/config.yaml
+++ b/ingest/defaults/config.yaml
@@ -57,7 +57,7 @@ curate:
     isolate-lineage-source: sample_type
     biosample-acc: biosample_accessions
     sra-accs: sra_accessions
-    submitter-names: authors
+    submitter-names: full_authors
     submitter-affiliation: institution
   # Standardized strain name regex
   # Currently accepts any characters because we do not have a clear standard for strain names across pathogens
@@ -83,11 +83,11 @@ curate:
       "los", "nad", "of", "op", "sur", "the", "y"
     ]
   # Metadata field that contains the list of authors associated with the sequence
-  authors_field: "authors"
+  authors_field: "full_authors"
   # Default value to use if the authors field is empty
   authors_default_value: "?"
   # Name to use for the generated abbreviated authors field
-  abbr_authors_field: "abbr_authors"
+  abbr_authors_field: "authors"
   # Path to the manual annotations file
   # The path should be relative to the ingest directory
   annotations: "defaults/annotations.tsv"
@@ -117,7 +117,7 @@ curate:
     'is_lab_host',
     #'date_submitted',
     #'sra_accession',
-    #'abbr_authors',
+    #'full_authors',
     #'reverse',
     'authors',
     'latitude',

--- a/ingest/scripts/post_process_metadata.py
+++ b/ingest/scripts/post_process_metadata.py
@@ -31,17 +31,6 @@ def _set_url(record):
     return "https://www.ncbi.nlm.nih.gov/nuccore/" + str(record["accession"])
 
 
-def _set_paper_url(record):
-    """Set paper_url from a comma separate list of PubMed IDs in publication. Only use the first ID."""
-    if (not record["publications"]):
-        return ""
-
-    return (
-        "https://www.ncbi.nlm.nih.gov/pubmed/"
-        + str(record["publications"]).split(",")[0]
-    )
-
-
 def main():
     args = parse_args()
 
@@ -49,9 +38,6 @@ def main():
         record = json.loads(record)
         record["strain"] = _set_strain_name(record)
         record["url"] = _set_url(record)
-        #record["paper_url"] = _set_paper_url(record)
-        # record["serotype"] = _set_dengue_serotype(record) # WNV
-        record["authors"] = record["abbr_authors"]
         stdout.write(json.dumps(record) + "\n")
 
 


### PR DESCRIPTION
**Context**
As part of continually updating compliance to the pathogen-repo-guide, this PR switches to full_authors and authors fields

**Description**
In the ingest workflow, switch `authors` to `full_authors` and `abbr_authors` to `authors` so that the abbreviated author field is used by `augur export` in the phylogenetic workflow. This follows the guidance in this [pathogen-repo-guide commit.](https://github.com/nextstrain/pathogen-repo-guide/commit/ba9442943753e0bb9ce5014f9dd264238b15f614)
