### PR TITLE
Automation: Migrate from staging to live

### DIFF
--- a/phylogenetic/build-configs/nextstrain-automation/config.yaml
+++ b/phylogenetic/build-configs/nextstrain-automation/config.yaml
@@ -1,4 +1,4 @@
 custom_rules:
   - build-configs/nextstrain-automation/deploy.smk
 
-deploy_url: "s3://nextstrain-staging"
+deploy_url: "s3://nextstrain-data"

--- a/phylogenetic/defaults/description.md
+++ b/phylogenetic/defaults/description.md
@@ -4,13 +4,13 @@ Special thanks to individuals at the [Northwest Pathogen Genomics Center of Exce
 
 **We maintain four views of WNV evolution:**
 
-The first view is [`wnv/global`](https://next.nextstrain.org/staging/WNV/global/), which focuses on the broader viral diversity for all WNV sequences submitted to GenBank that contain at least 75% of the genome length. Sequences are aligned to the reference sequence [AF260968](https://www.ncbi.nlm.nih.gov/nuccore/AF260968), which is the first WNV L1 (cluster 1) strain recovered in Egypt from 1951 ([Mencattelli, et al, 2023](https://doi.org/10.1038/s41467-023-42185-7)).
+The first view is [`wnv/global`](https://next.nextstrain.org/WNV/global/), which focuses on the broader viral diversity for all WNV sequences submitted to GenBank that contain at least 75% of the genome length. Sequences are aligned to the reference sequence [AF260968](https://www.ncbi.nlm.nih.gov/nuccore/AF260968), which is the first WNV L1 (cluster 1) strain recovered in Egypt from 1951 ([Mencattelli, et al, 2023](https://doi.org/10.1038/s41467-023-42185-7)).
 
-The second view is [`wnv/wa`](https://next.nextstrain.org/staging/WNV/wa/), which focuses on WNV sequences from Washington State, with tiered subsampling from Washington, surrounding states, and across the USA. Sequences are aligned to reference sequence [AF481864](https://www.ncbi.nlm.nih.gov/nuccore/AF481864), a non-USA WNV sequence most closely related to the sequences isolated from New York in 1999 ([Hadfield et al, 2019](https://doi.org/10.1371/journal.ppat.1008042))
+The second view is [`wnv/wa`](https://next.nextstrain.org/WNV/wa/), which focuses on WNV sequences from Washington State, with tiered subsampling from Washington, surrounding states, and across the USA. Sequences are aligned to reference sequence [AF481864](https://www.ncbi.nlm.nih.gov/nuccore/AF481864), a non-USA WNV sequence most closely related to the sequences isolated from New York in 1999 ([Hadfield et al, 2019](https://doi.org/10.1371/journal.ppat.1008042))
 
-The third view is [`wnv/lineage-1A`](https://next.nextstrain.org/staging/WNV/lineage-1A/), which focuses on the global lineage 1A. Sequences are aligned to RefSeq reference [NC_009942](https://www.ncbi.nlm.nih.gov/nuccore/NC_001563), and the phylogenetic tree is outgroup-rooted using a near Lineage-1B sequence [KX394399](https://www.ncbi.nlm.nih.gov/nuccore/KX394399).
+The third view is [`wnv/lineage-1A`](https://next.nextstrain.org/WNV/lineage-1A/), which focuses on the global lineage 1A. Sequences are aligned to RefSeq reference [NC_009942](https://www.ncbi.nlm.nih.gov/nuccore/NC_001563), and the phylogenetic tree is outgroup-rooted using a near Lineage-1B sequence [KX394399](https://www.ncbi.nlm.nih.gov/nuccore/KX394399).
 
-The fourth view is [`wnv/lineage-2`](https://next.nextstrain.org/staging/WNV/lineage-2/), which focuses on a global lineage 2. Sequences are aligned to the RefSeq reference [NC_001563](https://www.ncbi.nlm.nih.gov/nuccore/NC_001563).
+The fourth view is [`wnv/lineage-2`](https://next.nextstrain.org/WNV/lineage-2/), which focuses on a global lineage 2. Sequences are aligned to the RefSeq reference [NC_001563](https://www.ncbi.nlm.nih.gov/nuccore/NC_001563).
 
 #### Underlying data
 


### PR DESCRIPTION
## Description of proposed changes

Currently the automated workflow is publishing Nextstrain trees to the staging site, which is useful for initial review and debugging. However, since we've reviewed and rerooted the trees the site seems ready to be pushed live.

This change publishes Nextstrain trees to the live site. 

GH Action Phylogenetic Check ran to completion: https://github.com/nextstrain/WNV/actions/runs/13823318916

* https://next.nextstrain.org/WNV/global/
* https://next.nextstrain.org/WNV/wa/
* https://next.nextstrain.org/WNV/lineage-1A/
* https://next.nextstrain.org/WNV/lineage-2/

## Related issue(s)

## Checklist

- [x] Checks pass
- [ ] Update manifest_core.json https://github.com/nextstrain/nextstrain.org/pull/1127

