### PR TITLE
Update host type mapping

### DIFF
--- a/ingest/defaults/host_hostgenus_hosttype_map.tsv
+++ b/ingest/defaults/host_hostgenus_hosttype_map.tsv
@@ -156,6 +156,7 @@ Falco peregrinus	Falco	Bird
 Falco punctatus	Falco	Bird
 Falco sparverius	Falco	Bird
 Falco tinnunculus	Falco	Bird
+Fringillidae	Fringillidae	Bird
 Fulica	Fulica	Bird
 Galliformes	Galliformes	Bird
 Gallus gallus	Gallus	Bird
@@ -175,6 +176,7 @@ Larus delawarensis	Larus	Bird
 Larus michahellis	Larus	Bird
 Larus smithsonianus	Larus	Bird
 Lathamus discolor	Lathamus	Bird
+Locustella naevia	Locustella	Bird
 Loriini	Loriini	Bird
 Meleagris gallopavo	Meleagris	Bird
 Mergus squamatus	Mergus	Bird
@@ -190,6 +192,7 @@ Parus major	Parus	Bird
 Passer domesticus	Passer	Bird
 Passer sp.	Passer	Bird
 Passeridae	Passeridae	Bird
+Passeriformes	Passeridae	Bird
 Pelecanus	Pelecanus	Bird
 Pelecanus erythrorhynchos	Pelecanus	Bird
 Pelecanus occidentalis	Pelecanus	Bird
@@ -254,6 +257,7 @@ Hyalomma scupense	Hyalomma	Tick
 Ixodoidea	Ixodoidea	Tick
 Rhipicephalus guilhoni	Rhipicephalus	Tick
 Rhipicephalus pulchellus	Rhipicephalus	Tick
+Rhipicephalus rossicus	Rhipicephalus	Tick
 Bos taurus	Bos	Other
 Camelus bactrianus	Camelus	Other
 Camelus dromedarius	Camelus	Other


### PR DESCRIPTION
## Description of proposed changes

Updated the host type mapping file, updated host coloring previewed at:

* https://next.nextstrain.org/staging/WNV/trials/20250303host/WNV/global?c=host_type

## Related issue(s)

* https://github.com/nextstrain/WNV/issues/69

## Checklist

- [x] Checks pass
- [x] Ran a phylogenetic check


