### PR TITLE
ingest: Remove use of ncov-ingest geolocation rules

### DIFF
--- a/ingest/defaults/config.yaml
+++ b/ingest/defaults/config.yaml
@@ -32,10 +32,6 @@ ncbi_datasets_fields:
 
 # Config parameters related to the curate pipeline
 curate:
-  # URL pointed to public generalized geolocation rules
-  # For the Nextstrain team, this is currently
-  # "https://raw.githubusercontent.com/nextstrain/ncov-ingest/master/source-data/gisaid_geoLocationRules.tsv"
-  geolocation_rules_url: "https://raw.githubusercontent.com/nextstrain/ncov-ingest/master/source-data/gisaid_geoLocationRules.tsv"
   # The path to the local geolocation rules within the pathogen repo
   # The path should be relative to the ingest directory.
   local_geolocation_rules: "defaults/geolocation-rules.tsv"


### PR DESCRIPTION
## Description of proposed changes

Remove the use of the ncov-ingest geolocation rules since Augur now uses the built-in geolocation rules by default.

Depends on the release of
<nextstrain/augur#1745>

## Related issue(s)

Part of nextstrain/public#17

## Checklist

- [ ] Checks pass

