### PR TITLE
Fixup Ingest: Only merge lineage information for INSDC data

### DIFF
--- a/ingest/rules/nextclade.smk
+++ b/ingest/rules/nextclade.smk
@@ -46,16 +46,16 @@ rule select_USA_potential_samples:
     params:
         id_field=config["curate"]["output_id_field"],
     shell:
-        """
+        r"""
         tsv-filter -H \
-          --not-regex 'lineage:1B|[2,3,4,5,6,7,8]' \
+          --not-regex 'lineage:^(1B|2|3|4|5|6|7|8)$' \
           {input.pathoplexus_tsv} \
         > {output.potential_1A_samples}
 
         augur filter \
             --sequences {input.sequences} \
             --metadata {output.potential_1A_samples} \
-            --metadata-id-column {params.id_field} \
+            --metadata-id-columns {params.id_field} \
             --output-sequences {output.sequences}
         """
 

--- a/ingest/rules/nextclade.smk
+++ b/ingest/rules/nextclade.smk
@@ -25,8 +25,9 @@ rule pathoplexus_classify:
         accession_field=config["pathoplexus"]["accession_field"],
         id_field=config["curate"]["output_id_field"],
     shell:
-        """
+        r"""
         curl "{params.URL}?dataFormat=TSV&downloadAsFile=false&fields={params.fields}" \
+        | tsv-filter -H --not-empty {params.accession_field} \
         | uniq \
         | csvtk -t rename -f {params.accession_field} -n {params.id_field} \
         >  {output.pathoplexus_tsv}


### PR DESCRIPTION
## Description of proposed changes

The latest WNV[ ingest action](https://github.com/nextstrain/WNV/actions/runs/14933909453) was failing on rule [select_USA_potential_samples](https://github.com/nextstrain/WNV/blob/036de0e3bb4b0209620e8b1b1df0bfa48ecb4719/ingest/rules/nextclade.smk#L35-L59) in augur filter with:

```bash
ERROR: The following strains are duplicated in 'data/pathoplexus_results/potential_1A_samples.tsv':
```

Due to the fact that there were no strain IDs listed in the above error message, we traced it back to multiple records having the empty string "" as INSDC accession even as it may have a Pathoplexus accession (e.g. not yet submitted to INSDC). Since we're only currently analyzing INSDC WNV sequences (GenBank), we filtered the records to only those with INSDC accessions for the moment.

Full thread in [slack](https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1746814036808899).

Other fixes include refactoring the regex and fixing a misspelled parameter in augur filter.

## Related issue(s)


## Checklist


- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
