### PR TITLE
Draft of future augur subsample config

### DIFF
--- a/phylogenetic/defaults/all-lineages/config.yaml
+++ b/phylogenetic/defaults/all-lineages/config.yaml
@@ -9,8 +9,15 @@ subsample:
     include:
       - defaults/include.txt
   samples:
-    region:
+    focal:
+      query: division == 'WA'
+      subsample_max_sequences: 300
+    contextual:
+      query: country == 'USA' & division != 'WA'
+      subsample_max_sequences: 50
+    background:
+      query: country != 'USA'
       group_by:
-        - region
-        - year
-      subsample_max_sequences: 3000
+        - country
+        - month
+      subsample_max_sequences: 50

--- a/phylogenetic/defaults/all-lineages/config.yaml
+++ b/phylogenetic/defaults/all-lineages/config.yaml
@@ -14,6 +14,7 @@ subsample:
       subsample_max_sequences: 300
     contextual:
       query: country == 'USA' & division != 'WA'
+      proximity_target: focal
       subsample_max_sequences: 50
     background:
       query: country != 'USA'

--- a/phylogenetic/defaults/all-lineages/config.yaml
+++ b/phylogenetic/defaults/all-lineages/config.yaml
@@ -21,3 +21,7 @@ subsample:
         - country
         - month
       subsample_max_sequences: 50
+  output:
+    - background
+    - contextual
+    - focal

--- a/phylogenetic/defaults/all-lineages/config.yaml
+++ b/phylogenetic/defaults/all-lineages/config.yaml
@@ -12,10 +12,15 @@ subsample:
     focal:
       query: division == 'WA'
       subsample_max_sequences: 300
-    contextual:
+    contextual_similar:
       query: country == 'USA' & division != 'WA'
       proximity_target: focal
-      subsample_max_sequences: 50
+      subsample_max_sequences: 25
+    contextual_other:
+      query: country == 'USA' & division != 'WA'
+      subsample_max_sequences: 25
+      exclude_samples:
+        - contextual_similar
     background:
       query: country != 'USA'
       group_by:
@@ -24,5 +29,6 @@ subsample:
       subsample_max_sequences: 50
   output:
     - background
-    - contextual
+    - contextual_similar
+    - contextual_other
     - focal


### PR DESCRIPTION
This PR contains a draft of configuration support by potential future versions of `augur subsample`. I'm keeping it as draft to prevent accidental merge, but the changes are open for feedback on configuration design, as it may affect the initial config schema used in #96.

## Discussion threads

- [x] [default `output` behavior?](https://github.com/nextstrain/WNV/pull/97#discussion_r2244258819) output all samples
- [ ] [support `input`?](https://github.com/nextstrain/WNV/pull/97#discussion_r2244264994)
- [x] [support `num_per_focal`?](https://github.com/nextstrain/WNV/pull/97#discussion_r2244278103) maybe, but it would require changes in `augur filter`