### PR TITLE
Configuration improvements

### DIFF
--- a/phylogenetic/defaults/config.yaml
+++ b/phylogenetic/defaults/config.yaml
@@ -16,8 +16,7 @@ builds: ['all-lineages']
 # See Nextstrain documentation for an explanation of how subsampling configuration works:
 # <https://docs.nextstrain.org/en/latest/guides/bioinformatics/filtering-and-subsampling.html#generalizing-subsampling-in-a-workflow>
 subsampling:
-  region: --query "is_lab_host != 'true'" --query-columns is_lab_host:str --min-length '8200' --group-by region year --subsample-max-sequences 3000 --exclude defaults/exclude.txt
-  force_include: --exclude-all --include defaults/include.txt
+  region: --query "is_lab_host != 'true'" --query-columns is_lab_host:str --min-length '8200' --group-by region year --subsample-max-sequences 3000 --exclude defaults/exclude.txt --exclude-all --include defaults/include.txt
 
 refine:
   treetime_params: --coalescent opt --date-inference marginal --date-confidence --keep-polytomies --clock-rate 0.000755

--- a/phylogenetic/defaults/config.yaml
+++ b/phylogenetic/defaults/config.yaml
@@ -16,7 +16,14 @@ builds: ['all-lineages']
 # See Nextstrain documentation for an explanation of how subsampling configuration works:
 # <https://docs.nextstrain.org/en/latest/guides/bioinformatics/filtering-and-subsampling.html#generalizing-subsampling-in-a-workflow>
 subsampling:
-  region: --query "is_lab_host != 'true'" --query-columns is_lab_host:str --min-length '8200' --group-by region year --subsample-max-sequences 3000 --exclude defaults/exclude.txt --exclude-all --include defaults/include.txt
+  region: >-
+    --query "is_lab_host != 'true'"
+    --query-columns is_lab_host:str
+    --min-length '8200'
+    --group-by region year
+    --subsample-max-sequences 3000
+    --exclude defaults/exclude.txt
+    --include defaults/include.txt
 
 refine:
   treetime_params: --coalescent opt --date-inference marginal --date-confidence --keep-polytomies --clock-rate 0.000755

--- a/phylogenetic/defaults/config.yaml
+++ b/phylogenetic/defaults/config.yaml
@@ -13,57 +13,8 @@ inputs:
 
 builds: ['all-lineages']
 
-#subsampling:
-  #all: --min-length '9800' --query "country == 'USA' & accession != 'NC_009942'"
-
-# Define named subsampling groups below (e.g., "state", "country", "region",
-# etc.). The workflow will run an `augur filter` command with the arguments
-# defined by each named group. Each `augur filter` command operates on all
-# available metadata and sequences and produces a text file containing the list
-# of strain names that passed the filters. The workflow will collect the union
-# of all strain names from the subsampling files and output the corresponding
-# subset of metadata and sequences that will be used to build the phylogeny.
-#
-# As an example, we could define two named subsampling groups like the
-# following:
-#
-# ```
-# subsampling:
-#   state: --query "division == 'WA'" --subsample-max-sequences 5000
-#   neighboring_state: --query "division in ['CA', 'ID', 'OR', 'NV']" --subsample-max-sequences 5000
-# ```
-#
-# These named subsampling groups will translate to the following two `augur filter` commands:
-#
-# ```
-# augur filter \
-#   --sequences data/sequences_all.fasta \
-#   --metadata data/metadata_all.tsv \
-#   --query "division == 'WA'" --subsample-max-sequences 5000 \
-#   --output-strains results/subsampled_strains_state.txt
-#
-# augur filter \
-#   --sequences data/sequences_all.fasta \
-#   --metadata data/metadata_all.tsv \
-#   --query "division in ['CA', 'ID', 'OR', 'NV']" --subsample-max-sequences 5000 \
-#   --output-strains results/subsampled_strains_neighboring_state.txt
-# ```
-#
-# Then, the workflow will collect the strains from each command to extract the
-# corresponding metadata and sequences with the following command:
-#
-# ```
-# augur filter \
-#   --sequences data/sequences_all.fasta \
-#   --metadata data/metadata_all.tsv \
-#   --exclude-all \
-#   --include results/subsampled_strains_state.txt results/subsampled_strains_neighboring_state.txt \
-#   --output-sequences results/sequences_filtered.fasta \
-#   --output-metadata results/metadata_filtered.tsv
-# ```
-#
-# This command excludes all strains by default and then forces the inclusion of
-# the strains selected by the subsampling logic defined above.
+# See Nextstrain documentation for an explanation of how subsampling configuration works:
+# <https://docs.nextstrain.org/en/latest/guides/bioinformatics/filtering-and-subsampling.html#generalizing-subsampling-in-a-workflow>
 subsampling:
   region: --query "is_lab_host != 'true'" --query-columns is_lab_host:str --min-length '8200' --group-by region year --subsample-max-sequences 3000 --exclude defaults/exclude.txt
   force_include: --exclude-all --include defaults/include.txt

--- a/phylogenetic/defaults/lineage-1A/config.yaml
+++ b/phylogenetic/defaults/lineage-1A/config.yaml
@@ -3,7 +3,14 @@ root: "KX394399"
 builds: ['lineage-1A']
 
 subsampling:
-  region: --query "is_lab_host != 'true' & lineage == '1A'" --query-columns is_lab_host:str --min-length '8200' --group-by region year --subsample-max-sequences 3000 --exclude defaults/exclude.txt --include defaults/lineage-1A/include.txt
+  region: >-
+    --query "is_lab_host != 'true' & lineage == '1A'"
+    --query-columns is_lab_host:str
+    --min-length '8200'
+    --group-by region year
+    --subsample-max-sequences 3000
+    --exclude defaults/exclude.txt
+    --include defaults/lineage-1A/include.txt
 
 # Clock rate from Table 1 of May et al, 2010: https://pmc.ncbi.nlm.nih.gov/articles/PMC3067944/
 refine:

--- a/phylogenetic/defaults/lineage-1A/config.yaml
+++ b/phylogenetic/defaults/lineage-1A/config.yaml
@@ -3,8 +3,7 @@ root: "KX394399"
 builds: ['lineage-1A']
 
 subsampling:
-  region: --query "is_lab_host != 'true' & lineage == '1A'" --query-columns is_lab_host:str --min-length '8200' --group-by region year --subsample-max-sequences 3000 --exclude defaults/exclude.txt
-  force_include: --exclude-all --include defaults/lineage-1A/include.txt
+  region: --query "is_lab_host != 'true' & lineage == '1A'" --query-columns is_lab_host:str --min-length '8200' --group-by region year --subsample-max-sequences 3000 --exclude defaults/exclude.txt --include defaults/lineage-1A/include.txt
 
 # Clock rate from Table 1 of May et al, 2010: https://pmc.ncbi.nlm.nih.gov/articles/PMC3067944/
 refine:

--- a/phylogenetic/defaults/lineage-2/config.yaml
+++ b/phylogenetic/defaults/lineage-2/config.yaml
@@ -3,8 +3,7 @@ root: "best"
 builds: ['lineage-2']
 
 subsampling:
-  region: --query "is_lab_host != 'true' & lineage == '2'" --query-columns is_lab_host:str --min-length '8200' --group-by region year --subsample-max-sequences 3000 --exclude defaults/exclude.txt
-  force_include: --exclude-all --include defaults/lineage-2/include.txt
+  region: --query "is_lab_host != 'true' & lineage == '2'" --query-columns is_lab_host:str --min-length '8200' --group-by region year --subsample-max-sequences 3000 --exclude defaults/exclude.txt --include defaults/lineage-2/include.txt
 
 # Clock rate from McMullen et al, 2013: https://pmc.ncbi.nlm.nih.gov/articles/PMC3709619/
 refine:

--- a/phylogenetic/defaults/lineage-2/config.yaml
+++ b/phylogenetic/defaults/lineage-2/config.yaml
@@ -3,7 +3,14 @@ root: "best"
 builds: ['lineage-2']
 
 subsampling:
-  region: --query "is_lab_host != 'true' & lineage == '2'" --query-columns is_lab_host:str --min-length '8200' --group-by region year --subsample-max-sequences 3000 --exclude defaults/exclude.txt --include defaults/lineage-2/include.txt
+  region: >-
+    --query "is_lab_host != 'true' & lineage == '2'"
+    --query-columns is_lab_host:str
+    --min-length '8200'
+    --group-by region year
+    --subsample-max-sequences 3000
+    --exclude defaults/exclude.txt
+    --include defaults/lineage-2/include.txt
 
 # Clock rate from McMullen et al, 2013: https://pmc.ncbi.nlm.nih.gov/articles/PMC3709619/
 refine:


### PR DESCRIPTION
## Description of proposed changes

Various improvements for #96 that are applicable even without `augur subsample`.

## Related issue(s)

N/A

## Discussion threads

- [x] [Write config with `{build}` in path?](https://github.com/nextstrain/WNV/pull/98#discussion_r2250139163) yes, and use f-strings
- [x] [`builds` vs. `build`?](https://github.com/nextstrain/WNV/pull/98#discussion_r2250139338) Switch to `build`
- [x] [Keep using `wiildcard_constraints`?](https://github.com/nextstrain/WNV/pull/98#discussion_r2252427864) ~yes~ no longer applicable
- [x] [Continue using `all-lineages` as default build?](https://github.com/nextstrain/WNV/pull/98#discussion_r2252816573) yes
- [x] [Always run `write_config`?](https://github.com/nextstrain/WNV/pull/98#discussion_r2255049280) yes
- [x] [Remove comment on zstd compression requirement?](https://github.com/nextstrain/WNV/pull/98#discussion_r2263561940) no
- [x] [Update pathogen-repo-guide recommendation for an exhaustive default config?](https://github.com/nextstrain/WNV/pull/98#discussion_r2308218054) no

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Tested locally with commands:
    
    ```sh
    nextstrain build \
      phylogenetic \
      --configfile defaults/lineage-1A/config.yaml \
      --forceall --dry-run
    
    nextstrain build \
      phylogenetic \
      --configfile defaults/lineage-2/config.yaml \
      --forceall --dry-run
    
    nextstrain build \
      phylogenetic \
      --configfile defaults/all-lineages/config.yaml \
      --forceall --dry-run
    ```

- [x] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
