### PR TITLE
Clarify changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ We use this CHANGELOG to document breaking changes, new features, bug fixes, and
 
 * 8 September 2025: Configuration resolved at run time is now written to a file under `results/run_configs`. [PR #102](https://github.com/nextstrain/WNV/pull/102) @victorlin
 * 8 September 2025: The phylogenetic workflow configuration now expects a new structure with most configuration defined under a build-specific key. See `phylogenetic/defaults/config.yaml` as an example. **This is a breaking change.** [PR #102](https://github.com/nextstrain/WNV/pull/102) @victorlin
-* 8 September 2025: The phylogenetic workflow now runs all Nextstrain-maintained builds by default. This can be adjusted by a new configuration option, `builds`. **This is a breaking change.** [PR #102](https://github.com/nextstrain/WNV/pull/102) @victorlin
+* 8 September 2025: The phylogenetic workflow now runs all Nextstrain-maintained builds by default. This can be adjusted by the `builds` configuration option. **This is a breaking change.** [PR #102](https://github.com/nextstrain/WNV/pull/102) @victorlin
 * 8 September 2025: Support for manual subsampling by editing the file `phylogenetic/rules/subsampling_manual.smk` is no longer supported. **This is a breaking change.** [PR #102](https://github.com/nextstrain/WNV/pull/102) @victorlin
 * 24 March 2025: Add frequencies panel @j23414
 * 21 March 2025: Migrated WA specific config to NW-PaGe [PR#90] @j23414, @DOH-LMT2303, @DOH-PNT0303


### PR DESCRIPTION
The 'builds' config key had already existed prior to the change.
