### PR TITLE
fix(nextclade): remove invalid qc scoreWeight fields

### DIFF
--- a/nextclade/dataset/pathogen.json
+++ b/nextclade/dataset/pathogen.json
@@ -19,8 +19,7 @@
     "missingData": {
       "enabled": true,
       "missingDataThreshold": 2000,
-      "scoreBias": 500,
-      "scoreWeight": 50
+      "scoreBias": 500
     },
     "snpClusters": {
       "enabled": true,
@@ -30,8 +29,7 @@
     },
     "mixedSites": {
       "enabled": true,
-      "mixedSitesThreshold": 15,
-      "scoreWeight": 50
+      "mixedSitesThreshold": 15
     },
     "frameShifts": {
       "enabled": true,

--- a/nextclade/defaults/pathogen.json
+++ b/nextclade/defaults/pathogen.json
@@ -19,8 +19,7 @@
     "missingData": {
       "enabled": true,
       "missingDataThreshold": 2000,
-      "scoreBias": 500,
-      "scoreWeight": 50
+      "scoreBias": 500
     },
     "snpClusters": {
       "enabled": true,
@@ -30,8 +29,7 @@
     },
     "mixedSites": {
       "enabled": true,
-      "mixedSitesThreshold": 15,
-      "scoreWeight": 50
+      "mixedSitesThreshold": 15
     },
     "frameShifts": {
       "enabled": true,


### PR DESCRIPTION
Remove `scoreWeight` from `qc.missingData` and `qc.mixedSites` in the Nextclade dataset config (source and committed output).

The `scoreWeight` property is not defined on `QcRulesConfigMissingData` or `QcRulesConfigMixedSites` in the pathogen.json schema and is silently ignored. It is valid on `snpClusters`, `frameShifts`, and `stopCodons` (those are left unchanged).

- [x] Remove `qc.missingData.scoreWeight` from source and committed output
- [x] Remove `qc.mixedSites.scoreWeight` from source and committed output

> :warning: The existing dataset in `nextclade_data` is already patched in nextstrain/nextclade_data#440, so no immediate resubmission is needed. But without this upstream fix, the invalid fields will reappear on the next dataset submission from this workflow.

> :information_source: See [pathogen.json schema](https://github.com/nextstrain/nextclade/blob/master/packages/nextclade-schemas/input-pathogen-json.schema.json) for the `QcRulesConfigMissingData` and `QcRulesConfigMixedSites` definitions.

1. Related to: nextstrain/nextclade_data#440