### PR TITLE
Readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,24 +15,3 @@ Follow the [standard installation instructions](https://docs.nextstrain.org/en/l
 ## Documentation
 
 - [Running a pathogen workflow](https://docs.nextstrain.org/en/latest/tutorials/running-a-workflow.html)
-
-## Working on this repo
-
-This repo is configured to use [pre-commit](https://pre-commit.com),
-to help automatically catch common coding errors and syntax issues
-with changes before they are committed to the repo.
-.
-If you will be writing new code or otherwise working within this repo,
-please do the following to get started:
-
-1. install `pre-commit` by running either `python -m pip install
-   pre-commit` or `brew install pre-commit`, depending on your
-   preferred package management solution
-2. install the local git hooks by running `pre-commit install` from
-   the root of the repo
-3. when problems are detected, correct them in your local working tree
-   before committing them.
-
-Note that these pre-commit checks are also run in a GitHub Action when
-changes are pushed to GitHub, so correcting issues locally will
-prevent extra cycles of correction.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository contains three workflows for the analysis of West Nile virus data:
 
 - [`ingest/`](./ingest) - Download data from GenBank, clean and curate it
-- [`phylogenetic/`](./phylogenetic) - Filter sequences, align, construct phylogeny and export for visualization
+- [`phylogenetic/`](./phylogenetic) - Workflow which produces JSONs for visualisation in Auspice
 - [`nextclade/`](./nextclade) - Create nextclade datasets
 
 Each folder contains a README.md with more information. The results of running both workflows are publicly visible at [nextstrain.org/WNV](https://nextstrain.org/WNV).
@@ -11,15 +11,6 @@ Each folder contains a README.md with more information. The results of running b
 ## Installation
 
 Follow the [standard installation instructions](https://docs.nextstrain.org/en/latest/install.html) for Nextstrain's suite of software tools.
-
-## Quickstart
-
-Run the default phylogenetic workflow via:
-```
-cd phylogenetic/
-nextstrain build .
-nextstrain view .
-```
 
 ## Documentation
 

--- a/phylogenetic/README.md
+++ b/phylogenetic/README.md
@@ -1,7 +1,11 @@
 # Phylogenetic
 
-This workflow uses WNV metadata and sequences to produce one [Nextstrain datasets][]
+This workflow uses already-curated WNV metadata and sequences to produce [Nextstrain datasets][]
 that can be visualized in Auspice.
+By default the curated data is sourced from our public S3 bucket and produces three analyses:
+1. all-lineages (`auspice/WNV_all-lineages.json`)
+2. Lineage 1A (`auspice/WNV_lineage-1A.json`)
+3. Lineage 2 (`auspice/WNV_lineage-2.json`)
 
 ## Workflow Usage
 


### PR DESCRIPTION
* Removed the quickstart section as that would run 3 full builds; I think a better starting place is to read the phylo README. * Updated the phyloREADME to reflect the actual builds being run.
* Removed the note about git pre-commit, as there's no configuration present. Closes #122 